### PR TITLE
Remove omscripts submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "omscripts"]
-	path = omscripts
-	url = git@bitbucket.org:outware/omscripts.git


### PR DESCRIPTION
OMScripts is a repository used in Outware to take care of some of the CI build processes.

This submodule is no longer required as this framework does not build using the same automated scripts.